### PR TITLE
docs: simple lexer rules are tried in order

### DIFF
--- a/lexer/simple.go
+++ b/lexer/simple.go
@@ -7,6 +7,7 @@ type SimpleRule struct {
 }
 
 // MustSimple creates a new Stateful lexer with only a single root state.
+// The rules are tried in order.
 //
 // It panics if there is an error.
 func MustSimple(rules []SimpleRule) *StatefulDefinition {
@@ -18,6 +19,7 @@ func MustSimple(rules []SimpleRule) *StatefulDefinition {
 }
 
 // NewSimple creates a new Stateful lexer with only a single root state.
+// The rules are tried in order.
 func NewSimple(rules []SimpleRule) (*StatefulDefinition, error) {
 	fullRules := make([]Rule, len(rules))
 	for i, rule := range rules {


### PR DESCRIPTION
This addition to `MustSimple` and `NewSimple` docs would help me when writing my lexer. I had to find the answer in https://github.com/alecthomas/participle/discussions/287#discussioncomment-4317476